### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -16,9 +16,7 @@
     {
       "plugin": "@nx/js/typescript",
       "options": {
-        "typecheck": {
-          "targetName": "typecheck"
-        },
+        "typecheck": { "targetName": "typecheck" },
         "build": {
           "targetName": "build",
           "configName": "tsconfig.lib.json",
@@ -39,12 +37,7 @@
         "typecheckTargetName": "typecheck"
       }
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
     {
       "plugin": "@nx/vite/plugin",
       "options": {
@@ -61,11 +54,7 @@
     {
       "plugin": "@nx/js/typescript",
       "include": ["libs/spellcasting-types/*", "libs/spellcasting-sdk/*"],
-      "options": {
-        "typecheck": {
-          "targetName": "typecheck"
-        }
-      }
+      "options": { "typecheck": { "targetName": "typecheck" } }
     },
     {
       "plugin": "@nx/webpack/plugin",
@@ -79,14 +68,8 @@
     }
   ],
   "targetDefaults": {
-    "test": {
-      "dependsOn": ["^build"]
-    },
-    "nx-release-publish": {
-      "options": {
-        "packageRoot": "{projectRoot}/dist"
-      }
-    }
+    "test": { "dependsOn": ["^build"] },
+    "nx-release-publish": { "options": { "packageRoot": "{projectRoot}/dist" } }
   },
   "generators": {
     "@nx/react": {
@@ -96,13 +79,8 @@
         "linter": "eslint",
         "bundler": "vite"
       },
-      "component": {
-        "style": "tailwind"
-      },
-      "library": {
-        "style": "tailwind",
-        "linter": "eslint"
-      }
+      "component": { "style": "tailwind" },
+      "library": { "style": "tailwind", "linter": "eslint" }
     }
   },
   "release": {
@@ -111,9 +89,8 @@
       "manifestRootsToUpdate": ["{projectRoot}", "{projectRoot}/dist"],
       "preVersionCommand": "npx nx run mcp-server:setup-publish"
     },
-    "changelog": {
-      "projectChangelogs": true,
-      "workspaceChangelog": false
-    }
-  }
+    "changelog": { "projectChangelogs": true, "workspaceChangelog": false }
+  },
+  "nxCloudId": "683743e68a52dc0839bafd8e",
+  "nxCloudUrl": "https://staging.nx.app"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://staging.nx.app/orgs/66570096dbcb650ad6e515d9/workspaces/683743e68a52dc0839bafd8e

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.